### PR TITLE
case/step: refresh README to shipped state + add verify-case-step-geometry skill

### DIFF
--- a/.claude/skills/verify-case-step-geometry/SKILL.md
+++ b/.claude/skills/verify-case-step-geometry/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: verify-case-step-geometry
+description: Rebuild the build123d metal-case STEP (case/step/) and MEASURE a geometry feature to confirm it is right — skin/wall thickness over a recess, a hole's depth/perpendicularity, or a screw hole's break-out margin — rather than eyeballing a render. Use after editing case_model.py (recess depth, skin thickness, screw-hole position/depth, rabbet, wall) and whenever the user asks "how thick is the skin / wall there", "is the hole deep enough / perpendicular", "will the screw break out", "verify the recess", or before committing a case change. NOT for firmware or PCB work.
+---
+
+# Verify a metal-case STEP feature (build123d)
+
+The case model (`case/step/case_model.py`, built by `build.py`) is measured, not
+eyeballed — a render hides thin skins, shallow holes and break-out. This skill is
+the loop used all through the case work: **build → validate → measure the specific
+feature the change was about → report the number**. It answers three questions with
+hard numbers:
+
+1. **Skin / wall thickness** over a recess (display/encoder pocket, a wall).
+2. **Hole depth + perpendicularity** — does a drill engage enough body, along the
+   tilted-bottom normal.
+3. **Screw break-out** — is the tapped-thread envelope fully buried in material.
+
+Repo dir: `/home/user/PolyKybd/case/step`
+Outputs: `metal-case-right.step`, `metal-case-left.step` (+ `.stl`).
+
+## When to expect which question
+
+| Change kind | Measure |
+|---|---|
+| Recess depth / "make the skin 1.2 mm" | skin thickness raycast over the pocket |
+| Drill hole depth / "2 mm deeper" | hole-span raycast; solid remaining below |
+| Screw-hole reposition / "might break out" | thread-envelope fill fraction |
+| Rabbet / wall tweak | `validate_step` solids==1 + wall raycast |
+
+Tell the user the number, not "looks fine".
+
+## Procedure
+
+1. **Build.** The full build is slow (~5–10 min) and memory-hungry — always via
+   `build.py` (it sets the `RLIMIT_AS` OOM cap). Run it in the background and read
+   the output file when it finishes; do not poll with a foreground `sleep`.
+   ```bash
+   cd /home/user/PolyKybd/case/step && python3 build.py
+   ```
+   A clean run prints `[right] … faces=… vol=… bbox=…` then `[left] …`.
+
+2. **Validate — the closed-solid gate.** ⚠️ `BRepCheck_Analyzer.IsValid()` passes an
+   OPEN SHELL; the real gate is **`solids == 1`** (a post-processing boolean that
+   silently no-ops leaves `solids=0`, inward bottom normals, "see through the case").
+   ```bash
+   python3 validate_step.py metal-case-right.step metal-case-left.step   # want: PASS, solids: 1
+   ```
+   If `solids: 0` → an open shell; the last rabbet/wall/USB boolean no-op'd (see the
+   README "Bottom-plate rabbet" traps) — fix before measuring anything else.
+
+3. **Measure the feature** with the helper below (`measure_case.py`, sitting beside
+   this SKILL.md). It raycasts and computes fill fractions on the built STEP:
+   Run it **from `case/step/`** (so it can `import case_model` / `plate_svg` and find
+   the `.step`). Reference it by its repo-root path:
+   ```bash
+   cd case/step
+   S=../../.claude/skills/verify-case-step-geometry/measure_case.py
+   python3 "$S" skin  -55 -5     # skin thickness over (x,y)
+   python3 "$S" hole  -88 62     # solid span at a hole (global frame)
+   python3 "$S" screw            # break-out fill % for every SCREW_HOLES entry (or pass an index)
+   ```
+   - **skin**: prints the sorted Z hits; a top-skin pair like `[17.30, 18.50]` = **1.20 mm**.
+     A recess floors low and the top solid span IS the skin. Sample a few (x,y) across
+     the pocket — the recess is not a point.
+   - **hole**: the solid spans a +Z ray crosses; the gap where the drill removed material
+     is the bore, the solid below it is what the screw bites into.
+   - **screw**: **flattens the part first** (holes are drilled perpendicular to the tilted
+     bottom, so break-out only reads right in the flattened frame), then measures the
+     **annular wall** between the pilot bore (Ø`SCREW_HOLE_D`) and the Ø2.2 thread envelope
+     over each `SCREW_HOLES` entry — the fraction of that tube that is solid. `~1.0` = the
+     thread is fully surrounded; a low value = it breaks out through a wall, so move the
+     hole outward until it's ~1.0. ⚠️ Measure the **annulus**, not a solid cylinder: the
+     STEP already has the bore subtracted, so a plain Ø2.2 cylinder caps at ~0.5 even when
+     perfectly buried (the hollow bore is half its volume).
+
+4. **Report the number** and whether it meets the target (e.g. "skin 1.20 mm ✓,
+   was 0.60"). Only then commit.
+
+## Measuring by hand (if the helper isn't present)
+
+Core recipe — a vertical ray, adjacent Z-hit pairs are solid spans:
+
+```python
+from build123d import import_step
+from OCP.gp import gp_Pnt, gp_Dir, gp_Lin
+from OCP.BRepIntCurveSurface import BRepIntCurveSurface_Inter
+part = import_step("metal-case-right.step").wrapped
+def zhits(x, y):
+    it = BRepIntCurveSurface_Inter(); it.Init(part, gp_Lin(gp_Pnt(x,y,-50), gp_Dir(0,0,1)), 1e-7)
+    zs=[]
+    while it.More(): zs.append(it.Pnt().Z()); it.Next()   # .Z() is a METHOD — call it
+    return sorted(zs)
+```
+
+Screw break-out — flatten first, then fraction of the annular wall (bore→envelope)
+that is solid (build123d `-`/`&` + volume):
+
+```python
+from build123d import import_step, Cylinder, Location, Pos
+from OCP.GProp import GProp_GProps
+from OCP.BRepGProp import BRepGProp
+from plate_svg import flatten                       # reuses case_model.flatten
+pf = flatten(import_step("metal-case-right.step"))  # holes -> perpendicular to +Z
+def vol(s):
+    g=GProp_GProps(); BRepGProp.VolumeProperties_s(s.wrapped, g); return g.Mass()
+env  = Cylinder(radius=1.1, height=6.5).moved(Location(Pos(x, y, zc)))   # Ø2.2 thread env
+bore = Cylinder(radius=0.8, height=8.5).moved(Location(Pos(x, y, zc)))   # Ø1.6 pilot bore
+tube = env - bore
+frac = vol(tube & pf) / vol(tube)      # ~1.0 buried; low = breaks out. (zc = ledge + h/2)
+```
+
+## Pitfalls
+
+- **`.Z()` / `.X()` are METHODS on `gp_Pnt`** — `it.Pnt().Z` (no parens) is a bound
+  method and `sorted()` throws `'<' not supported between … method and method`. Call them.
+- **`solids == 1` is the acceptance, not `IsValid()`.** A topology-only valid check
+  passes the open shell that a no-op'd boolean produces. Always run `validate_step.py`.
+- **The bottom is TILTED (−5° wedge).** Screw holes are drilled in the wedge-flattened
+  frame so their axes are perpendicular to the plate; when measuring hole *depth*, a
+  global +Z ray is still fine for the span, but reason about "perpendicular to the
+  bottom" in the flattened frame (see `plate_svg.py`/`case_model.py` `flatten`).
+- **Sample a recess at several (x,y).** One ray can miss a rounded corner or land on a
+  step; confirm the skin over the whole pocket, not one point. `[]` (no hits) = outside
+  the part footprint — move inward.
+- **Don't eyeball the STL/render for thickness or break-out.** That is exactly what
+  hid the 0.6 mm skin and the 44%-buried front screws this loop was built to catch.
+- **Build is slow + RAM-hungry — go through `build.py`** (it sets `RLIMIT_AS`); run it
+  in the background and read the output file on completion instead of a foreground wait.

--- a/.claude/skills/verify-case-step-geometry/measure_case.py
+++ b/.claude/skills/verify-case-step-geometry/measure_case.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Measure a built metal-case STEP feature — skin/wall thickness, hole span, or
+screw-hole break-out — with hard numbers instead of eyeballing a render.
+
+Run from case/step/ (so `import case_model` and the .step files resolve):
+    measure_case.py skin  X Y                 # solid Z-spans of a +Z ray through (X,Y)
+    measure_case.py hole  X Y                 # same, framed as bore + remaining solid
+    measure_case.py screw [I]                 # break-out fill % for SCREW_HOLES[I] (all if omitted)
+
+skin/hole: adjacent Z-hit pairs are solid spans (global frame). A recess floors low,
+so the TOP span is the skin (e.g. [17.30, 18.50] => 1.20 mm). '[]' = outside footprint.
+
+screw: ⚠️ holes are drilled in the WEDGE-FLATTENED frame (perpendicular to the tilted
+bottom), so break-out MUST be measured there — this mode FLATTENS the part (same
+flatten() as plate_svg.py), then fills a Ø2.2 (r=1.1) thread envelope of height
+SCREW_HOLE_DEPTH over each SCREW_HOLES[I] along +Z. ~1.0 = buried; low = breaks out.
+"""
+import sys, os
+from build123d import import_step, Cylinder, Location, Pos
+from OCP.gp import gp_Pnt, gp_Dir, gp_Lin
+from OCP.BRepIntCurveSurface import BRepIntCurveSurface_Inter
+from OCP.GProp import GProp_GProps
+from OCP.BRepGProp import BRepGProp
+
+sys.path.insert(0, os.getcwd())   # run from case/step/ so `import case_model`/`plate_svg` resolve
+STEP = os.environ.get("CASE_STEP", "metal-case-right.step")
+LEDGE_ZFLAT = 0.64   # flattened-frame ledge/plate-seat level (holes engage upward from here)
+
+
+def zhits(part_w, x, y):
+    it = BRepIntCurveSurface_Inter()
+    it.Init(part_w, gp_Lin(gp_Pnt(x, y, -50), gp_Dir(0, 0, 1)), 1e-7)
+    zs = []
+    while it.More():
+        zs.append(it.Pnt().Z())          # .Z() is a METHOD — call it
+        it.Next()
+    return sorted(zs)
+
+
+def spans(zs):
+    return [(zs[i], zs[i + 1]) for i in range(0, len(zs) - 1, 2)]
+
+
+def _vol(shape):
+    g = GProp_GProps(); BRepGProp.VolumeProperties_s(shape.wrapped, g); return g.Mass()
+
+
+def main():
+    a = sys.argv[1:]
+    if not a:
+        print(__doc__); sys.exit(2)
+    mode = a[0]
+    part = import_step(STEP)
+
+    if mode in ("skin", "hole"):
+        x, y = float(a[1]), float(a[2])
+        zs = zhits(part.wrapped, x, y)
+        print(f"{STEP}  ({x},{y})  z-hits: {['%.2f' % z for z in zs]}")
+        for lo, hi in spans(zs):
+            print(f"    solid {lo:.2f}..{hi:.2f}  = {hi - lo:.2f} mm")
+        if mode == "skin" and spans(zs):
+            lo, hi = spans(zs)[-1]
+            print(f"  -> TOP-skin span = {hi - lo:.2f} mm")
+
+    elif mode == "screw":
+        # Holes are drilled in the wedge-flattened frame -> flatten before measuring.
+        # The STEP already has the pilot bore subtracted, so measure the ANNULAR WALL
+        # between the bore (SCREW_HOLE_D) and the Ø2.2 thread envelope: fraction of that
+        # tube that is solid. ~1.0 = the thread is fully surrounded; low = it breaks out.
+        import case_model as cm
+        from plate_svg import flatten
+        pf = flatten(part)
+        h = cm.SCREW_HOLE_DEPTH
+        r_env, r_bore = 1.1, cm.SCREW_HOLE_D / 2.0     # Ø2.2 thread env, Ø1.6 pilot bore
+        zc = LEDGE_ZFLAT + h / 2.0                      # engage upward from the ledge seat
+        idxs = [int(a[1])] if len(a) > 1 else range(len(cm.SCREW_HOLES))
+        for i in idxs:
+            x, y = cm.SCREW_HOLES[i]
+            env = Cylinder(radius=r_env, height=h).moved(Location(Pos(x, y, zc)))
+            bore = Cylinder(radius=r_bore, height=h + 2).moved(Location(Pos(x, y, zc)))
+            tube = env - bore                          # the annular wall the thread cuts into
+            vt = _vol(tube)
+            frac = _vol(tube & pf) / vt if vt else 0.0
+            verdict = "BURIED ✓" if frac > 0.97 else ("marginal" if frac > 0.9 else "BREAKS OUT ✗")
+            print(f"screw #{i+1} ({x:.1f},{y:.1f}) flat  wall Ø{2*r_bore:.1f}->Ø{2*r_env:.1f} × {h}"
+                  f"  -> solid {frac:.2f}  {verdict}")
+
+    else:
+        print(__doc__); sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/case/step/README.md
+++ b/case/step/README.md
@@ -112,9 +112,9 @@ Parameters at the top of `case_model.py`:
 
 ```python
 WITH_BOTTOM_RABBET = True
-LIP_DROP  = 1.0    # lip depth, perpendicular from the cut-off plane
-RABBET_UP = 1.0    # inner ledge recess above the cut-off plane
-LIP_W     = 4.0    # outer lip band width (uniform on every edge)
+LIP_DROP  = 0.9    # lip depth, perpendicular from the cut-off plane (ref: -0.9)
+RABBET_UP = 0.6    # inner ledge recess above the cut-off plane (ref ledge ~+0.65)
+LIP_W     = 2.0    # outer lip/ledge-cut inset (uniform); MUST be < the thin front wall (see above)
 ```
 
 Set `WITH_BOTTOM_RABBET = False` for the pure SCAD reproduction.
@@ -172,15 +172,18 @@ The SCAD `branding()` engraves **PolyKybd** (Arial Bold Italic, 0.35 mm deep) on
 case bottom**. The metal case has no such bottom face, so `add_branding()` places the same
 engraving on the flat top area the **convex hull** created in front of the thumb cluster —
 the extra bezel the hull fills in where the raw outline is concave (the "little extra area"
-from the convex-hull outer shell). It is drawn as **two staggered lines** — **"Poly"** up/left,
-**"Kybd"** down/right — at a smaller size than the SCAD's single size-12 line (the top band is
-narrower), centred toward the case centre. Engraved (subtracted) to match the SCAD's `difference()`.
+from the convex-hull outer shell). It is drawn as a **single "PolyKybd" line** at a smaller
+size than the SCAD's size-12 line (the top band is narrower), centred toward the case centre.
+Engraved (subtracted) to match the SCAD's `difference()`. (`BRAND_LINES` as a 2-tuple staggers
+onto two lines — **"Poly"** up/left, **"Kybd"** down/right — via `BRAND_STAG_X/Y`; the single
+line was chosen as final. The separate raised-`hull()` **PolyKybd logo** that was tried earlier
+was dropped entirely — "better without it".)
 
 ```python
 WITH_BRANDING = True
-BRAND_LINES = ("Poly", "Kybd"); BRAND_SIZE = 7.0; BRAND_DEPTH = 0.35   # two staggered lines
-BRAND_X = 12.0; BRAND_Y = -47.0; BRAND_TOP_Z = 18.5                    # block centre on the bezel
-BRAND_STAG_X = 3.0; BRAND_STAG_Y = 3.6                                 # 2nd line offset (+X, −Y)
+BRAND_LINES = ("PolyKybd",); BRAND_SIZE = 7.0; BRAND_DEPTH = 0.35      # single line (2-tuple = staggered)
+BRAND_X = 16.0; BRAND_Y = -47.0; BRAND_TOP_Z = 18.5                    # block centre on the bezel
+BRAND_STAG_X = 3.0; BRAND_STAG_Y = 3.6                                 # 2nd-line offset if 2 lines
 BRAND_FONT = ".../LiberationSans-BoldItalic.ttf"                       # Arial Bold Italic metric clone
 ```
 
@@ -210,9 +213,18 @@ at the pocket edge ≈(−55,−5), found by the vertex nearest `ENCODER_ANCHOR`
 encoder cutout stays** (that face is still cut through with the other switches — the real
 through-hole is needed); on top of it an **enlarged BLIND body recess** is added: the same
 face **enlarged** (offset `ENCODER_GROW`) to reach past the pocket edge, cut at the **same
-z-depth as the display box** (z 12.9–17.9) so it stays under the top skin (z 17.9–18.5).
+z-depth as the display box** so it stays under the top skin.
 `ENCODER_ANCHOR` is a final-frame coord, converted to the pre-`X_SHIFT` frame where the
 display Box + `cut_faces` live.
+
+⚠️ **Top skin over BOTH recesses is 1.2 mm, not 0.6 mm (thickened for the metal case).** The
+display + encoder recesses originally floored at **z17.9**, leaving only a **0.6 mm** skin under
+the z18.5 top plateau — too thin for a *metal* case. Both were dropped to floor at **z17.3**
+(skin = 18.5 − 17.3 = **1.2 mm**) by shortening the two pockets: the display `Box` height and
+the encoder blind-recess `extrude(enc_face, amount=…)` were each reduced by 0.6 mm (encoder
+`5 → 4.4`). ⚠️ **Only the BLIND recess depths changed — the encoder *through-cut* (`enc_src` in
+`cut_faces`) is untouched.** Verify the skin with a vertical raycast over each pocket (see
+"Measuring the solid" below): a hit pair of `[17.30, 18.50]` is the correct 1.2 mm skin.
 
 The recess Y-extent is additionally grown by `ENCODER_GROW_Y` (X unchanged): the enlarged
 `enc_face` is **scaled in Y about its centre** so the bbox height grows by `ENCODER_GROW_Y`
@@ -261,22 +273,87 @@ keeping the `raw_faces_all` + `offset` path.
 
 4 pilot holes for **M2×4 self-tapping** screws that fix the bottom plate (aluminium → no
 thread; the screw cuts its own on first use, so `SCREW_HOLE_D = 1.6` is a tight thread-cutting
-pilot). Drilled in `add_bottom_rabbet` in the **wedge-flattened frame**, so they run
-perpendicular to the plate, each engaging ~`SCREW_HOLE_DEPTH` (4.5 mm) of body above the ledge.
+pilot). Drilled in `add_bottom_rabbet` in the **wedge-flattened frame** — so the hole **axes
+run perpendicular to the odd, tilted bottom plane**, not to global Z (this was an explicit
+design check). Each engages `SCREW_HOLE_DEPTH` (**6.5 mm** = the M2×4 screw + ~2 mm slack) of
+body above the ledge. `WITH_SCREW_HOLES` toggles them; positions are `SCREW_HOLES` (flattened XY).
+
 ⚠️ The case walls are thin, so the holes sit in the thicker **corner L-junctions** (outer shell
 solid, any opening faces the interior). The two **front** corners are useless — the wedge makes
 the front shallow, with no material at the ledge — so the front holes are **moved north to the
-side "knees"** (where the diagonal front wall meets the vertical side wall), the southern-most
-solid+clearance spots. Positions in `SCREW_HOLES` (flattened XY); `WITH_SCREW_HOLES` toggles them.
+side "knees"** (where the diagonal front wall meets the vertical side wall).
+
+**Placement + break-out verification (how the positions were chosen):**
+- **On the ledge shelf, not the wall.** A good spot is the **centroid of the ledge-shelf face**
+  ("middle of the ledge") — hole #1 landed there naturally; #2/#3/#4 were moved onto their own
+  shelf centroids, then nudged by hand (#2 → x99).
+- **Break-out is checked, not eyeballed.** For a candidate `(x,y)`, build the **thread envelope**
+  as a `Cylinder(radius≈1.1, Ø2.2)` (the tapped/expanded ⌀, wider than the 1.6 pilot) at the
+  hole depth and compute the **volume-fill fraction** `vol(cyl ∩ part) / vol(cyl)`. ~1.0 = fully
+  buried; a low fraction (the front holes were only ~44 % enclosed when too far inboard) means
+  the thread would break out through a wall. The front holes were pushed **1.5 mm outward** until
+  the envelope was fully enclosed (edge distance ≈ 2.3 mm).
+- The **bottom-plate SVG** (`plate_svg.py`, below) emits these same `SCREW_HOLES` as Ø2.2 M2
+  clearance circles so the plate matches the tapped case.
+
+## Bottom-plate SVG (`plate_svg.py`)
+
+Emits a flat, dimensioned SVG of the bottom plate for **both** halves
+(`bottom_plate_right.svg`, `bottom_plate_left.svg`), extracted from the built STEP:
+
+```bash
+python3 plate_svg.py        # -> bottom_plate_{right,left}.svg
+```
+
+The plate **drops into the recess and rests on the ledge**, so the cut line is the **recess
+opening**, not the rim. Everything is measured in the **wedge-flattened frame** (the plane the
+plate lies in — same `flatten()` as the rabbet/holes) and drawn top-view (Y flipped for SVG,
+un-mirrored; the left file is the pure X-mirror). Two outlines + the holes:
+- **black solid = plate cut line = recess opening** — the **ledge outer wire** at flattened
+  `z ≈ +0.64` (`outer_loop(pf, 0.64)`). Add your own ~0.1–0.2 mm inward fit clearance.
+- **grey dashed = outer rim edge** (case outer boundary) at flattened `z ≈ −0.86` — reference only.
+- **red = the 4 `SCREW_HOLES`** as **Ø2.2 mm M2-clearance** circles + centre cross-hairs.
+
+`outer_loop(pf, zlevel)` grabs the largest downward face (`normal.Z < −0.7`) whose `bbox.min.Z`
+matches the level and samples its biggest wire at 0.4 mm steps. ⚠️ The two z-levels (`+0.64`
+ledge, `−0.86` rim) are the flattened-frame rabbet levels — if `LIP_DROP`/`RABBET_UP` change,
+re-check them (they are literals in `main()`).
+
+## Measuring the solid (raycast + fill fraction)
+
+The reusable way to *measure* a built solid (skin thickness, wall thickness, hole depth) without
+eyeballing — used to verify the 1.2 mm skins and the screw break-out above:
+
+```python
+from build123d import import_step
+from OCP.gp import gp_Pnt, gp_Dir, gp_Lin
+from OCP.BRepIntCurveSurface import BRepIntCurveSurface_Inter
+part = import_step("metal-case-right.step").wrapped
+def zhits(x, y):                       # sorted Z of every surface a +Z ray through (x,y) crosses
+    it = BRepIntCurveSurface_Inter(); it.Init(part, gp_Lin(gp_Pnt(x, y, -50), gp_Dir(0, 0, 1)), 1e-7)
+    zs = []
+    while it.More(): zs.append(it.Pnt().Z()); it.Next()   # note: .Z() is a METHOD, call it
+    return sorted(zs)
+# adjacent pairs = solid spans. Over a recess: [17.30, 18.50] => 1.20 mm top skin.
+```
+
+- **Skin / wall thickness** = the gap of a solid span (`zhits` pair) over the feature.
+- **Screw break-out** = volume-fill fraction of the thread envelope:
+  `Cylinder(radius=1.1, height=h)` at the hole, then `vol(cyl & part) / vol(cyl)` (build123d
+  `&` + `GProp_GProps`/`BRepGProp.VolumeProperties_s`). ~1.0 = buried; low = breaks out.
+
+The **`verify-case-step-geometry` skill** wraps both of these + the build/validate loop.
 
 ## Acceptance (validate_step.py)
 
 Both sides pass:
 
 - `valid B-Rep = True`
-- **curved faces > 0** (519 — real corner cylinders + rim tori)
+- **exactly one solid** with positive volume (`solids == 1`) — the check that catches the
+  open-shell/inward-normal failure `BRepCheck_Analyzer.IsValid()` passes (see the rabbet notes)
+- **curved faces > 0** (~700 — real corner cylinders + rim tori)
 - **max edge tolerance ≈ 1e-5 mm** (vs 0.148 in the mesh export)
-- ~1359 faces (vs ~15 000 facets), bbox 200.1 × 142.9 × **25.7** mm (with the bottom
+- ~1643 faces (vs ~15 000 facets), bbox 200.1 × 142.9 × **25.6** mm (with the bottom
   rabbet; ~24.7 mm without it, i.e. the pure SCAD reproduction)
 
 ## Memory note


### PR DESCRIPTION
## Summary

Session-retro follow-up to #15. Brings the `case/step/README.md` design log up to the shipped model and captures the hard-won measurement workflow as a reusable hardware skill. **Docs + tooling only — no change to the model or the STEP output.**

Based on the `claude/metal-case-openscad-step-5cytot` branch (#15) so the diff is just these 3 files; retarget to `master` once #15 merges.

## README updates (`case/step/README.md`)

Several documented values had drifted from `case_model.py`; refreshed + added this session's learnings:

- **Rabbet params**: `LIP_DROP 1.0→0.9`, `RABBET_UP 1.0→0.6`, `LIP_W 4.0→2.0`.
- **Branding** is now a single **"PolyKybd"** line at `BRAND_X=16` (the separate raised logo was dropped).
- **Display + encoder recess top skins thickened 0.6→1.2 mm** — both pockets floor at z17.3 (encoder blind-recess `extrude 5→4.4`); the encoder **through-cut is untouched**.
- New **Bottom-plate SVG (`plate_svg.py`)** section — recess-opening = plate cut line, rim outer edge = reference, Ø2.2 M2 holes, wedge-flattened frame, left = X-mirror.
- **Screw holes**: axes perpendicular to the tilted bottom, ledge-centroid placement, thread-envelope break-out verification, depth `4.5→6.5 mm`.
- New **Measuring the solid** section — the `BRepIntCurveSurface_Inter` raycast + annular fill-fraction recipe. Acceptance updated to the `solids == 1` gate and ~1643 faces.

## New skill (`.claude/skills/verify-case-step-geometry/`)

A hardware skill (alongside `investigate-kicad-pcb`) that measures a built case feature with numbers instead of eyeballing a render: **build → validate (`solids == 1`) → measure skin/wall thickness, hole span, or screw break-out**.

- `SKILL.md` + `measure_case.py` (raycast + annular fill-fraction helper).
- Validated on the shipped STEP: encoder skin **1.20 mm**, all 4 screw walls **buried (1.00)**.
- Encodes two modeling subtleties the session hit: the screw check must **flatten first** (holes are drilled perpendicular to the tilted bottom) and measure the **annular wall** between bore and thread envelope (a solid cylinder caps at ~0.5 because the drilled bore is already subtracted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tyAeCRWQVAqgwYfPjdQFr

---
_Generated by [Claude Code](https://claude.ai/code/session_015tyAeCRWQVAqgwYfPjdQFr)_