### PR TITLE
check_frame: fail closed when openscad fails

### DIFF
--- a/parts/tools/check_frame.py
+++ b/parts/tools/check_frame.py
@@ -166,14 +166,24 @@ def intersect_volume(placement, workdir):
     fd, sf = tempfile.mkstemp(prefix='_check_tmp_', suffix='.scad', dir=CASE)
     with os.fdopen(fd, 'w') as fh:
         fh.write(src)
+    # Its own output file per call.  Sharing one path across the three
+    # placements means a failed export silently re-reads the PREVIOUS
+    # placement's mesh and reports its volume as this one's clearance.
+    ofd, of = tempfile.mkstemp(prefix='x_', suffix='.stl', dir=workdir)
+    os.close(ofd)
+    os.remove(of)                    # openscad writes it; absence is the signal
     try:
-        of = os.path.join(workdir, 'x.stl')
         r = subprocess.run(['openscad', '-o', of, '--export-format', 'asciistl', sf],
                            capture_output=True, text=True, cwd=CASE, timeout=900)
-        if 'Current top level object is empty' in (r.stderr + r.stdout):
+        out = r.stderr + r.stdout
+        # Order matters: openscad exits 1 for an EMPTY result and 1 for a syntax
+        # error alike (verified), so the marker has to be tested before the code.
+        if 'Current top level object is empty' in out:
             return 0.0
+        if r.returncode != 0:
+            raise RuntimeError(f'openscad exited {r.returncode}:\n{out[-800:]}')
         if not os.path.exists(of) or os.path.getsize(of) == 0:
-            raise RuntimeError(f'openscad produced nothing:\n{r.stderr[-800:]}')
+            raise RuntimeError(f'openscad produced nothing:\n{out[-800:]}')
         tris, _ = load_stl(of)
         return volume(tris) * 1000.0
     finally:


### PR DESCRIPTION
Follow-up to #19, which merged before this landed.

## The bug

`intersect_volume()` is what gates whether the diffuser frame fits the spacer. It ran three placements — as-fitted, spacer-flipped, and the displaced positive control — and each one:

- wrote to **the same output path** (`workdir/x.stl`), and
- **ignored openscad's return code**.

An empty result writes no file at all, so a *failed* export left the previous placement's mesh sitting at that path. The next call happily loaded it and reported its volume as this placement's clearance. That is a false PASS in a collision check — the failure mode you least want in the script whose whole job is to say "no collision."

## The fix

Each call now writes its own `mkstemp` output, and a non-zero exit raises instead of falling through.

The **ordering is load-bearing and not guessable**: openscad exits `1` for an EMPTY result and `1` for a syntax error alike (verified both). So the `Current top level object is empty` marker has to be tested *before* the return code — reverse them and every clean no-collision result raises instead of reporting 0.0 mm³.

```python
out = r.stderr + r.stdout
# Order matters: openscad exits 1 for an EMPTY result and 1 for a syntax
# error alike (verified), so the marker has to be tested before the code.
if 'Current top level object is empty' in out:
    return 0.0
if r.returncode != 0:
    raise RuntimeError(f'openscad exited {r.returncode}:\n{out[-800:]}')
```

## Verification

Probed by feeding `intersect_volume()` a real syntax error: it now raises, where before it returned the previous placement's `112.4 mm³`.

⚠️ An **undefined module does not work as a probe** here — openscad only *warns* about one and still exports successfully, so it exercises nothing. That was my first attempt and it proved nothing; a genuine syntax error is what actually exercises the path.

Full suite still green on the current tree:

```
mesh integrity and wall thickness
  PASS  left/right: watertight, min wall 1.000 mm, web under engraving 0.85 mm
left/right symmetry   PASS  volumes match, bounding boxes mirror (0.0000 mm)
plate trap            PASS  worst +0.513 mm at (-3.00, +0.25)
spacer clearance      PASS  both flips 0.000 mm3; control detects 112.4 mm3
all checks passed
```

The positive control still fires, which is what makes those two zeros mean "no collision" rather than "the test found no geometry."

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUbhQNpubfrBdkMVDV7cS4)_

## Summary by Sourcery

Ensure diffuser frame collision checks fail closed when OpenSCAD export fails.

Bug Fixes:
- Prevent intersect_volume from reusing a previous placement's mesh when an export fails by giving each placement its own temporary output file.
- Treat non-empty OpenSCAD failures as hard errors while still correctly interpreting empty geometry as a valid no-collision result.

Enhancements:
- Improve error reporting from OpenSCAD by capturing combined stdout/stderr and including recent output in failure messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frame intersection checks by handling empty geometry results as zero overlap.
  * Added clearer reporting for failed OpenSCAD operations.
  * Verified that exported files exist and contain data before completing the operation.
  * Prevented conflicts when multiple OpenSCAD exports run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->