### PR TITLE
U12/U13: correct Manufacturer field to Nexperia

### DIFF
--- a/poly_kybd/ni_buffer2.kicad_sch
+++ b/poly_kybd/ni_buffer2.kicad_sch
@@ -495,7 +495,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" "TI"
+		(property "Manufacturer" "Nexperia"
 			(at 136.525 71.755 0)
 			(effects
 				(font
@@ -640,7 +640,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer" "TI"
+		(property "Manufacturer" "Nexperia"
 			(at 136.525 135.255 0)
 			(effects
 				(font


### PR DESCRIPTION
## What

Follow-up to #23. That PR retargeted U12/U13 from the EOL TI/TECH PUBLIC
`C151890` to Nexperia `74AHC1G125GW,125` (`C85397`) and updated `Value`,
`Datasheet`, `MPN`, `JLC` and `LCSC` — but left `Manufacturer` reading `TI`.

## Field state on U12/U13

| Field | Before #23 | After #23 | This PR |
|---|---|---|---|
| `Value` | `SN74LVC1G126DBVR` | `74AHC1G125GW,125` | — |
| `Datasheet` | ti.com | Nexperia | — |
| `MPN` | `C151890` | `74AHC1G125GW,125` | — |
| `JLC` | `C151890` | `C85397` | — |
| `LCSC` | `C151890` | `C85397` | — |
| **`Manufacturer`** | `TI` | **`TI`** ❌ | **`Nexperia`** ✅ |
| `RoHS` | `x` | `x` | unchanged — 138 uses project-wide |
| `Description` | *(empty)* | *(empty)* | unchanged — 183 uses project-wide |

`Nexperia` is already the spelling used elsewhere in the project (5 occurrences).

## Why it matters before F8

`Manufacturer` propagates to the footprint on **Update PCB from Schematic**
and feeds the CE parts list. The PCB currently still carries the whole old
identity — 14 footprints per side, both sides:

```
Value          SN74LVC1G126DBVR
JLC            C151890
LCSC           C151890
MPN            C151890
Manufacturer   TI
```

`LCSC`/`JLC` is what the JLC fabrication toolkit reads to build the BOM, so
until F8 runs, a gerber export would order the discontinued part. Landing this
first means one F8 pass carries the corrected manufacturer across too.

## Verification

Property-only change. Netlist re-traced afterwards — unchanged:
`/OE`→GND, `A`→A_IN/B_IN, `GND`→GND, `Y`→A_OUT/B_OUT, `VCC`→VCC. No shorts,
nothing floating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update schematic metadata for buffer U12/U13 to reference the correct Nexperia part instead of the obsolete TI component.

Bug Fixes:
- Correct the Manufacturer field for U12/U13 to Nexperia to match the already-updated value, datasheet, and part numbers.

Chores:
- Align schematic symbol properties so that generated PCBs and BOMs no longer reference the discontinued TI part for U12/U13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated manufacturer metadata for buffer components U12 and U13 from TI to Nexperia.
  * No changes to circuit connectivity or component behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->