### PR TITLE
RoHS: record the D2 Hottech entity decision

### DIFF
--- a/RoHS/RoHS-decisions-log.md
+++ b/RoHS/RoHS-decisions-log.md
@@ -1,7 +1,7 @@
 # PolyKybd — RoHS Documentation Decisions Log
 
 Standard applied throughout: **Directive 2011/65/EU (RoHS) as amended by (EU) 2015/863.**
-Last updated: 2026-08-07.
+Last updated: 2026-09-02.
 
 This file records the decisions made while assembling the RoHS evidence for the CE technical file,
 so the results can be reviewed and reproduced.

--- a/RoHS/RoHS-decisions-log.md
+++ b/RoHS/RoHS-decisions-log.md
@@ -39,13 +39,20 @@ so the results can be reviewed and reproduced.
     Its SOD coverage stops at **SOD-123**, and the report states its results "refer only to the
     sample(s) tested". D2 is SOD-323, so the package was never actually covered. `parts.csv` had
     recorded D2 as `x Email sent` throughout, which was the accurate status.
-  - ⚠️ **Two limitations to state if the file is ever challenged**, both normal for an SMD part
-    but worth being able to answer: the sample was **tested as a whole** (not separated into
-    homogeneous materials — the report says so explicitly, and RoHS limits formally apply per
-    homogeneous material); and the applicant is **Shenzhen Hottech Electronics**, while LCSC lists
-    the part's manufacturer as *Guangdong* Hottech. The report carries a remark that the two are
-    "Group-subsidiary relations" — but that linkage is **according to the client's statement**,
-    not something CTI verified. The report is also a package-family report, not MPN-specific.
+  - ✅ **DECIDED 2026-09-02 — Shenzhen and Guangdong Hottech are treated as ONE entity.** The
+    applicant on the report is **Shenzhen Hottech Electronics**, while LCSC (and JLC's matched
+    part on the v3.3 assembly order) lists the manufacturer as *Guangdong* Hottech. The report
+    carries a remark that the two are "Group-subsidiary relations"; that linkage is **according
+    to the client's statement**, not something CTI verified, but it is accepted here as
+    sufficient — same group, same product line. This is a **stated position, not an open
+    question**: do not re-raise it as a gap. If it is ever challenged and a firmer basis is
+    wanted, the cheap ask is written confirmation from Hottech that the two are the same legal
+    entity or a declared group, which converts a client statement into supplier correspondence.
+  - ⚠️ **Two limitations remain, as disclosures rather than decisions** — both are inherent to
+    the report and normal for an SMD part, but state them if the file is challenged: the sample
+    was **tested as a whole** (not separated into homogeneous materials — the report says so
+    explicitly, and RoHS limits formally apply per homogeneous material); and it is a
+    **package-family report** (`SOD-123/323/523/723`), not MPN-specific to `1N5819WS`.
   - **Consequence:** no part change needed. The PAKER `B5819WS` / `C5278927` alternative
     (`2401041156_PAKER-B5819WS_C5278927.pdf`, SOD-323, "Halogen free and RoHS compliant") is no
     longer required — and is the weaker option anyway: 2,250 in stock against Hottech's 5.6M, and

--- a/RoHS/RoHS-decisions-log.md
+++ b/RoHS/RoHS-decisions-log.md
@@ -45,9 +45,17 @@ so the results can be reviewed and reproduced.
     carries a remark that the two are "Group-subsidiary relations"; that linkage is **according
     to the client's statement**, not something CTI verified, but it is accepted here as
     sufficient — same group, same product line. This is a **stated position, not an open
-    question**: do not re-raise it as a gap. If it is ever challenged and a firmer basis is
-    wanted, the cheap ask is written confirmation from Hottech that the two are the same legal
-    entity or a declared group, which converts a client statement into supplier correspondence.
+    question**: do not re-raise it as a gap.
+    - **Source of the linkage, in full:** the remark is carried *inside the report itself* —
+      `ROHS-2025-HottechElectronics-CTI-A225024736310100101.pdf` (CTI report no.
+      A225024736310100101, 17 Apr 2025), held in `RoHS/`. ⚠️ **There is no separate
+      client-statement document on file**, and none is expected: the "client's statement"
+      is CTI's own attribution for that line in the report, not a record issued to us. So
+      the report is the entire traceable source for this decision — do not go looking for a
+      second one.
+    - **If it is ever challenged** and a firmer basis is wanted, the cheap ask is written
+      confirmation from Hottech that the two are the same legal entity or a declared group,
+      which converts a client statement into supplier correspondence.
   - ⚠️ **Two limitations remain, as disclosures rather than decisions** — both are inherent to
     the report and normal for an SMD part, but state them if the file is challenged: the sample
     was **tested as a whole** (not separated into homogeneous materials — the report says so

--- a/RoHS/RoHS-parts-evidence-table.md
+++ b/RoHS/RoHS-parts-evidence-table.md
@@ -1,7 +1,12 @@
 # RoHS evidence — parts to certificates
 
-Generated from **`parts-to-pdf-reference.xls`** (the source of truth) on 2026-08-24.
-Regenerate rather than hand-edit; edit the `.xls` and re-derive.
+**The table rows** are generated from **`parts-to-pdf-reference.xls`** (the source of truth),
+as of 2026-08-24. Regenerate rather than hand-edit; edit the `.xls` and re-derive.
+
+⚠️ **The prose sections below the table are hand-maintained and carry their own, later dates.**
+The `.xls` columns cannot express them, so they are not covered by the regenerate rule and are
+edited in place — most recently 2026-09-02 (the D2 Hottech entity decision). Read the date above
+as applying to the rows only; a decision dated after it is not a stale-vs-fresh contradiction.
 
 Standard applied throughout: **Directive 2011/65/EU as amended by (EU) 2015/863.**
 

--- a/RoHS/RoHS-parts-evidence-table.md
+++ b/RoHS/RoHS-parts-evidence-table.md
@@ -86,5 +86,7 @@ deliberate, not a mismatched reference:
   accepted on the belief that it covered the 323-series package; its sample list is
   `SOT-23, 323, 523, 723, … SOD-123`, where the `323` belongs to the **SOT** run, so
   **SOD-323 was never covered**. The 2025 CTI report lists `SOD-123/323/523/723`
-  explicitly. See `RoHS-decisions-log.md` for the two limitations to be able to answer
-  (tested as a whole; applicant is Shenzhen Hottech vs LCSC's Guangdong Hottech).
+  explicitly. See `RoHS-decisions-log.md` for the manufacturer-identity **decision**
+  (Shenzhen and Guangdong Hottech are treated as one entity, 2026-09-02) and the two
+  remaining **disclosures** (sample tested as a whole; package-family report, not
+  MPN-specific).


### PR DESCRIPTION
Notes only — `RoHS/RoHS-decisions-log.md` and the hand-written prose in `RoHS/RoHS-parts-evidence-table.md`. No part change, no board change, no BOM change.

## What changed

The CTI report closing `D2` (`C191023`, 1N5819WS, SOD-323) names **Shenzhen Hottech Electronics** as applicant, while LCSC — and JLC's matched part on the v3.3 assembly orders, both sides — lists the manufacturer as **Guangdong Hottech**. The log carried that as an open caveat *"to state if the file is ever challenged"*.

It is now a **stated position**: the two are treated as one entity, on the basis of the report's own "Group-subsidiary relations" remark. That linkage is still recorded as being *according to the client's statement* rather than CTI-verified — the decision is to accept it, not to pretend it was independently confirmed. The escalation, if it is ever challenged, is recorded too: written confirmation from Hottech that the two are the same legal entity or a declared group, which converts a client statement into supplier correspondence.

**Source traceability.** The entry now names where the linkage actually comes from — the remark is carried *inside the report itself*, `ROHS-2025-HottechElectronics-CTI-A225024736310100101.pdf` (report no. A225024736310100101, 17 Apr 2025), held in `RoHS/`. ⚠️ It also states plainly that **no separate client-statement document exists**: "according to the client's statement" is CTI's own attribution for that line, not a record issued to us. Saying so stops the next reader spending a round hunting for a second source.

## Why bother writing it down

An open caveat in a compliance file gets re-raised. This evidence has already been re-examined twice, once because the earlier rationale rested on **misreading a `SOT-323` sample as `SOD-323`** — the 2020 report's list is `SOT-23, 323, 523, 723, … SOD-123`, where the `323` belongs to the SOT run, so the package had never actually been covered. Leaving a decided question phrased as an open one invites a third round.

## Review round — one finding was right, and it was mine

⚠️ **An earlier version of this PR left the two files contradicting each other, and the description said the opposite.** The body claimed `RoHS-parts-evidence-table.md` was untouched *"because it is generated from `parts-to-pdf-reference.xls`"*. That reasoning holds for the **table rows** — but the file also carries **hand-written prose sections** the `.xls` columns cannot produce, and one of them still read:

> See `RoHS-decisions-log.md` for the two limitations to be able to answer (tested as a whole; applicant is Shenzhen Hottech vs LCSC's Guangdong Hottech).

Wrong on both counts after the first commit: the entity question is no longer a limitation *to answer*, and the second remaining disclosure is the package-family scope, not the entity name. Fixed in `ec018a6`, together with a `Last updated` date that still said `2026-08-07` on a file carrying a `2026-09-02` entry.

Only the prose is edited. The **rows are still exactly as generated** from `parts-to-pdf-reference.xls` on 2026-08-24, so the regenerate-don't-hand-edit rule is intact.

## What deliberately did NOT change

- **The two remaining limitations stay**, re-labelled as *disclosures* rather than open questions: the sample was **tested as a whole** rather than separated into homogeneous materials (RoHS limits formally apply per homogeneous material), and it is a **package-family report** (`SOD-123/323/523/723`) rather than MPN-specific to `1N5819WS`. Both are inherent to the report; no decision makes them go away.
- **The generated table rows.** See above.
- **No part substitution.** The PAKER `B5819WS` / `C5278927` alternative remains unnecessary and remains the weaker option — 2,250 in stock against Hottech's 5.6M, 9 A surge against 25 A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TdVkG4xm84QHBhBEYQUBe

## Summary by Sourcery

Document the accepted D2 Hottech manufacturer-identity decision while keeping the existing RoHS evidence and part-selection status unchanged.

Enhancements:
- Record the decision to treat Shenzhen and Guangdong Hottech as one entity based on the CTI report's attributed group-subsidiary statement, while preserving the source limitations and escalation path.
- Clarify that the evidence table rows remain generated from the spreadsheet while its hand-maintained prose can be updated independently.
- Reframe the remaining whole-sample and package-family scope issues as disclosures rather than unresolved questions.

Documentation:
- Update the RoHS decisions log and evidence-table prose with the D2 Hottech entity decision, source traceability, dates, and remaining disclosures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the RoHS decisions log with a formal decision dated September 2, 2026, treating Shenzhen and Guangdong Hottech as one entity for the D2 (1N5819WS) entry.
  * Documented the CTI report as the source for the manufacturer relationship and retained written supplier confirmation as a follow-up option.
  * Clarified that testing covered the sample as a whole rather than separate homogeneous materials.
  * Documented that the report applies to the SOD-123/323/523/723 package family rather than specifically to 1N5819WS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->